### PR TITLE
Consistency in require usage

### DIFF
--- a/lib/transactionlog.coffee
+++ b/lib/transactionlog.coffee
@@ -1,4 +1,4 @@
-fs = require 'fs'
+fs = require('fs')
 
 jspack = require('jspack').jspack
 

--- a/test/test_trade.coffee
+++ b/test/test_trade.coffee
@@ -1,6 +1,6 @@
 BD = require('bigdecimal')
 
-chai = require 'chai'  
+chai = require('chai')
 chai.should()
 expect = chai.expect
 assert = chai.assert


### PR DESCRIPTION
Convention normally dictates the use of `foo = require('bar')`.

In some places here you were using `foo = require 'bar'`.

It's always best to use the same approach throughout.
