### PR TITLE
Licence changed to collective

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Paul S. Bohm <enki@bbq.io>
+Copyright (c) 2013 Buttercoin Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bitcoin",
     "buttercoin"
   ],
-  "author": "Paul Bohm <enki@bbq.io> (http://paulbohm.com/)",
+  "author": "Buttercoin Developers (http://github.com/buttercoin/)",
   "license": "MIT",
   "readmeFilename": "README.md"
 }


### PR DESCRIPTION
If this is to be a collaborative project then the licence should be in a collaborative name. Whilst the work of Paul is important, this is not a one man project and **cannot** be licensed as such.
