### PR TITLE
Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+before_install:
+  - npm install coffee-script
+  - npm install mocha
+  - npm install chai
+node_js:
+  - "0.10.3"
+  - "0.10"
+  - "0.8"
+  - "0.6"
+notifications:
+  irc: "irc.freenode.org#buttercoin-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ node_js:
   - "0.10.3"
   - "0.10"
   - "0.8"
-  - "0.6"
 notifications:
   irc: "irc.freenode.org#buttercoin-dev"


### PR DESCRIPTION
Travis is a free and open source [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) service for the open source community.

This is the YAML file that is used to test against any commits and/or pulls to the repo.

I have integrated functionality to ping results to the IRC channel for development. This is done so that we can be aware of any changes in real time as not all the developers would have access to the email address set for this repo.

This would require registration to [Travis CI](https://travis-ci.org/) which is free of charge and is done via OAuth from your Github account. This registration only needs to be done with an account able to access the repo.
