### PR TITLE
make test.sh actually run

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,5 @@
+#!/bin/sh
+
+PATH=./node_modules/.bin:$PATH
+
 mocha  --compilers coffee:coffee-script -R spec  test/*


### PR DESCRIPTION
i don't know if it's actual problem but `npm install` by default is installing mocha into node_modules/.bin and it's not in PATH
