### PR TITLE
Specify port for the test api

### DIFF
--- a/test/api.coffee
+++ b/test/api.coffee
@@ -13,9 +13,10 @@ describe 'Api', ->
 
   it 'should start and provide a WS server', ->
     api = new Api
-    api.start =>
+    api.start {port: 3022, host: "0.0.0.0"}, () =>
+      console.log 'called api callback'
 
-    client = new WebSocket("ws://localhost:3001")
+    client = new WebSocket("ws://localhost:3022")
     client.on 'connection', () ->
       client.send '{"itsjson":"morejson"}'
 


### PR DESCRIPTION
...and give a callback to log connection to console. 
Previously, the tests would fail if the engine were running, due to using default ports for the api initialization. 
Tests now pass regardless of engine state. 
