### PR TITLE
removed homebrew, simplified with packages for git and node

### DIFF
--- a/doc/INSTALL_OSX.md
+++ b/doc/INSTALL_OSX.md
@@ -9,7 +9,7 @@ Download the Universal installer for Mac OS X:
 
 http://nodejs.org/download/
 
-_Note: buttercoin requires node >= 10.4_
+_Note: buttercoin requires node version 0.8 or newer_
 
 Run the installer and install node.
 

--- a/doc/INSTALL_OSX.md
+++ b/doc/INSTALL_OSX.md
@@ -6,6 +6,7 @@ Installing node.js and npm
 ---
 
 Download the Universal installer for Mac OS X, for the latest version of node:
+
 _Note: node >= 0.10.4_
 
 http://nodejs.org/download/

--- a/doc/INSTALL_OSX.md
+++ b/doc/INSTALL_OSX.md
@@ -5,11 +5,11 @@ Installing on Mac OSX
 Installing node.js and npm
 ---
 
-Download the Universal installer for Mac OS X:
+Download the Universal installer for Mac OS X, for the latest version of node:
+_Note: node >= 0.10.4_
 
 http://nodejs.org/download/
 
-_Note: buttercoin requires node version 0.8 or newer_
 
 Run the installer and install node.
 

--- a/doc/INSTALL_OSX.md
+++ b/doc/INSTALL_OSX.md
@@ -2,26 +2,23 @@ Installing on Mac OSX
 =====================
 
 
-Using Homebrew
---------------
+Installing node.js and npm
+---
 
-The easiest way to install and run on Mac OSX is using Homebrew (http://mxcl.github.io/homebrew/)
+Download the Universal installer for Mac OS X:
 
-Install Homebrew
-----------------
+http://nodejs.org/download/
 
-To install homebrew, if you have not already, try this command:
+_Note: buttercoin requires node >= 10.4_
 
-    ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"
+Run the installer and install node.
 
-then, check that it is working and update it:
+Install git
+---
 
-    brew update
+Download the installer (DMG) and run it to install git:
 
-Install git, the node.js runtime and node package manager
------------
-
-    brew install git node npm
+http://git-scm.com/download/mac
 
 Cloning the buttercoin repository to a local copy
 -------------------------------------------------
@@ -34,7 +31,7 @@ Installing the remaining dependencies
     cd buttercoin
     npm install 
 
-The `npm install` command will use the package.json file in buttercoin to find all node dependencies
+_Note: The `npm install` command will use the package.json file in buttercoin to find all node dependencies_
 
 Test and Run
 ------------
@@ -57,4 +54,4 @@ If all goes well, you will see the address for the main user interface:
 
 Point your browser at the URL reported and you will see the front-end
 
-Smooth as butter. 
+Smooth as butter


### PR DESCRIPTION
Cleaned up the Mac OS X installation document. 

Removed the homebrew instructions, the idea being that if you already have or know about homebrew, you'd probably just use it to install node, npm and git anyway, and don't need instructions. 

Learned how to squash and how to do a pull request from another branch to make it easier to push changes later, without merge commit.
