### PR TITLE
Add coffeescript global dependency

### DIFF
--- a/doc/INSTALL_LINUX.md
+++ b/doc/INSTALL_LINUX.md
@@ -15,7 +15,8 @@ Installing the remaining dependencies
 -------------------------------------
 
     cd buttercoin
-    npm install 
+    npm install
+    sudo npm install -g coffee-script
 
 The `npm install` command will use the package.json file in buttercoin to find all node dependencies
 

--- a/doc/INSTALL_OSX.md
+++ b/doc/INSTALL_OSX.md
@@ -32,7 +32,8 @@ Installing the remaining dependencies
 -------------------------------------
 
     cd buttercoin
-    npm install 
+    npm install
+    sudo npm install -g coffee-script
 
 The `npm install` command will use the package.json file in buttercoin to find all node dependencies
 


### PR DESCRIPTION
If you want to run the start.sh file, you need to have coffeescript installed globally, and the docs fail to say that. I just added them to the OS X and Linux ones.
