### PR TITLE
Include Arch Linux install instructions, other small improvements

### DIFF
--- a/doc/INSTALL_LINUX.md
+++ b/doc/INSTALL_LINUX.md
@@ -4,7 +4,13 @@ Installing on Linux
 Install git, the node.js runtime and node package manager
 -----------
 
+#### On Debian-based systems:
+
     apt-get install git node npm
+
+#### On Arch Linux:
+
+    pacman -S git nodejs
 
 Cloning the buttercoin repository to a local copy
 -------------------------------------------------
@@ -16,9 +22,13 @@ Installing the remaining dependencies
 
     cd buttercoin
     npm install
-    sudo npm install -g coffee-script
 
-The `npm install` command will use the package.json file in buttercoin to find all node dependencies
+The `npm install` command will use the package.json file in buttercoin
+to find all node dependencies, and install them locally to node_modules.
+
+The command might fail if a `https_proxy` environment variable is set.
+If this is the case, a workaround is to `unset` it.
+
 
 Test and Run
 ------------
@@ -39,6 +49,6 @@ If all goes well, you will see the address for the main user interface:
 
 >info: Buttercoin front-end server started on http://localhost:3000
 
-Point your browser at the URL reported and you will see the front-end
+Point your browser at the URL reported and you will see the front-end.
 
 Smooth as butter. 


### PR DESCRIPTION
A global install of coffee-script is probably not needed.

I have had issues before with a https_proxy envvar being set.
Cannot reproduce, but including just in case.

Line-wraps at ~80 symbols.
