### PR TITLE
use buttercoin-engine master branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/buttercoin/buttercoin.git"
   },
   "dependencies": {
-    "buttercoin-engine": "git://github.com/buttercoin/buttercoin-engine.git#v0.0.3",
+    "buttercoin-engine": "git://github.com/buttercoin/buttercoin-engine.git#master",
     "isnode": "*",
     "ws": "*",
     "wsany": "*",


### PR DESCRIPTION
Currently `npm install` will clone `buttercoin-engine` with tag `v0.0.3` which isn't compatible with current front-end and thus not working, this PR changes to `master` branch which works fine :)
